### PR TITLE
Add no-flip option

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ A Python toolkit for turning SVG line drawings into **Foundation Paper Piecing (
 - **Automatic Colors:** If your svg contains a bitmap image, automatically detects colors and uses them for each piece.
 - **Easy Labeling:** Groups and pieces are automatically labeled and placed.
 - **Automatic Flipping:** Printed pieces are automatically flipped, so you're working with the wrong side of the fabric.
+  Use `--no-flip` if you want the right side instead.
 
 ---
 
@@ -33,6 +34,8 @@ You can use [3groupA.svg](tests/e2e/fixtures/3groupA.svg) to get started.
 ### Run the script
 
 `python main.py tests/e2e/fixtures/3groupA.svg`
+ 
+Add `--no-flip` if you prefer pieces oriented like the SVG.
 
 ### FPP groups and sew order are automatically calculated
 
@@ -47,6 +50,7 @@ You can use [3groupA.svg](tests/e2e/fixtures/3groupA.svg) to get started.
 <p><img alt="Paper pattern pieces with seam allowances are packed on a page" src="images/3groupA_pieces.png" width="300"></p>
 
 Note that the pieces are flipped versions of the layout (i.e, they're the wrong side of the fabric).
+Use the `--no-flip` option to keep the original orientation.
 
 
 ---
@@ -68,6 +72,7 @@ Note that the pieces are flipped versions of the layout (i.e, they're the wrong 
 usage: main.py [-h] [--pdf PDF_FILE] [--png PNG_FILE]
                [--page-width PAGE_WIDTH_IN] [--page-height PAGE_HEIGHT_IN]
                [--seam-allowance SEAM_ALLOWANCE_IN] [--margin MARGIN_IN] [-v]
+               [--no-flip]
                svg_file
 
 FPP SVG to PDF/PNG pattern generator
@@ -86,6 +91,7 @@ options:
   --seam-allowance SEAM_ALLOWANCE_IN
                         Seam allowance in inches (default: 0.25)
   --margin MARGIN_IN    Page margin in inches (default: 0.5)
+  --no-flip             Do not flip pieces in the PDF (show right side)
   -v, --verbose         Enable verbose (INFO level) logging (default: False)
 ```
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,6 @@ A Python toolkit for turning SVG line drawings into **Foundation Paper Piecing (
 - **Automatic Colors:** If your svg contains a bitmap image, automatically detects colors and uses them for each piece.
 - **Easy Labeling:** Groups and pieces are automatically labeled and placed.
 - **Automatic Flipping:** Printed pieces are automatically flipped, so you're working with the wrong side of the fabric.
-  Use `--no-flip` if you want the right side instead.
 
 ---
 
@@ -35,8 +34,6 @@ You can use [3groupA.svg](tests/e2e/fixtures/3groupA.svg) to get started.
 
 `python main.py tests/e2e/fixtures/3groupA.svg`
  
-Add `--no-flip` if you prefer pieces oriented like the SVG.
-
 ### FPP groups and sew order are automatically calculated
 
 `open out/layout.png`
@@ -69,10 +66,9 @@ Use the `--no-flip` option to keep the original orientation.
 ## Usage
 
 ```bash
-usage: main.py [-h] [--pdf PDF_FILE] [--png PNG_FILE]
-               [--page-width PAGE_WIDTH_IN] [--page-height PAGE_HEIGHT_IN]
-               [--seam-allowance SEAM_ALLOWANCE_IN] [--margin MARGIN_IN] [-v]
-               [--no-flip]
+usage: main.py [-h] [--pdf PDF_FILE] [--png PNG_FILE] [--page-width PAGE_WIDTH_IN]
+               [--page-height PAGE_HEIGHT_IN] [--seam-allowance SEAM_ALLOWANCE_IN] [--margin MARGIN_IN]
+               [--no-flip] [-v]
                svg_file
 
 FPP SVG to PDF/PNG pattern generator
@@ -91,7 +87,7 @@ options:
   --seam-allowance SEAM_ALLOWANCE_IN
                         Seam allowance in inches (default: 0.25)
   --margin MARGIN_IN    Page margin in inches (default: 0.5)
-  --no-flip             Do not flip pieces in the PDF (show right side)
+  --no-flip             Do not flip pieces in the PDF (show right side) (default: False)
   -v, --verbose         Enable verbose (INFO level) logging (default: False)
 ```
 

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ class PipelineConfig:
     margin_in: float
     pdf_file: str
     png_file: str
+    flip_pieces: bool = True
 
 
 @dataclass
@@ -109,6 +110,12 @@ def parse_args() -> argparse.Namespace:
         type=float,
         default=DEFAULT_MARGIN_IN,
         help="Page margin in inches",
+    )
+    parser.add_argument(
+        "--no-flip",
+        dest="no_flip",
+        action="store_true",
+        help="Do not flip pieces in the PDF (show right side)",
     )
     parser.add_argument(
         "-v",
@@ -260,6 +267,7 @@ def export_pdf(state: PipelineState, config: PipelineConfig) -> None:
         page_width_in=config.page_width_in,
         page_height_in=config.page_height_in,
         svg_units_per_in=state.svg_units_per_in,
+        flip_y=config.flip_pieces,
     )
     logger.info("Saving PDF output to %s", config.pdf_file)
     pdf_writer(pdf_writer_args)
@@ -286,6 +294,7 @@ def run_pipeline(args: argparse.Namespace) -> None:
         margin_in=args.margin_in,
         pdf_file=args.pdf_file,
         png_file=args.png_file,
+        flip_pieces=not args.no_flip,
     )
     ensure_output_dirs(config)
     state = PipelineState(svg_file=args.svg_file)

--- a/pdf_writer.py
+++ b/pdf_writer.py
@@ -105,17 +105,16 @@ class PDFPolygonWriter:
         self.stroke_color: Any = black
         self.alpha: float = 1.0
         self.linewidth: float = 1.0
-        self._pts_per_in = inch
 
     def draw_polygon(self, poly: Polygon) -> None:
         """Draw a polygon on the instance's canvas using instance drawing attributes."""
         assert self.canvas is not None, "Canvas must be initialized before drawing."
         pts = []
         for x, y in poly.exterior.coords:
-            px = x / self.args.svg_units_per_in * self._pts_per_in
-            py = y / self.args.svg_units_per_in * self._pts_per_in
-            if self.args.flip_y:
-                py = self.args.page_height_in * self._pts_per_in - py
+            px = x / self.args.svg_units_per_in * inch
+            py = y / self.args.svg_units_per_in * inch
+            if not self.args.flip_y:
+                py = self.args.page_height_in * inch - py
             pts.append((px, py))
         path = self.canvas.beginPath()
         path.moveTo(*pts[0])
@@ -137,10 +136,10 @@ class PDFPolygonWriter:
         pt = Point(orig_x, orig_y)
         pt_rot = shapely_rotate(pt, args.rotation, origin=args.seam_poly.centroid)
         pt_tr = shapely_translate(pt_rot, args.dx, args.dy)
-        lx = pt_tr.x / self.args.svg_units_per_in * self._pts_per_in
-        ly = pt_tr.y / self.args.svg_units_per_in * self._pts_per_in
-        if self.args.flip_y:
-            ly = self.args.page_height_in * self._pts_per_in - ly
+        lx = pt_tr.x / self.args.svg_units_per_in * inch
+        ly = pt_tr.y / self.args.svg_units_per_in * inch
+        if not self.args.flip_y:
+            ly = self.args.page_height_in * inch - ly
         self.canvas.setFont("Helvetica-Bold", self.args.label_fontsize)
         self.canvas.setFillColor(black)
         offset = text_center_offset("Helvetica-Bold", self.args.label_fontsize)
@@ -159,7 +158,10 @@ class PDFPolygonWriter:
         """Write the polygons and labels to a PDF file."""
         self.canvas = rl_canvas.Canvas(
             self.args.filename,
-            pagesize=(self.args.page_width_in * self._pts_per_in, self.args.page_height_in * self._pts_per_in),
+            pagesize=(
+                self.args.page_width_in * inch,
+                self.args.page_height_in * inch,
+            ),
         )
         for placements in self.args.pages:
             for placement in placements:

--- a/tests/e2e/test_pipeline_svg.py
+++ b/tests/e2e/test_pipeline_svg.py
@@ -112,3 +112,34 @@ def test_pipeline_cli_e2e(tmp_path: Path):
     )
 
     assert "Done! Output written to:" in result.stdout
+
+
+def test_pipeline_cli_no_flip(tmp_path: Path):
+    project_root = Path(__file__).parent.parent.parent
+    main_py = project_root / "main.py"
+    input_svg = project_root / "tests" / "e2e" / "fixtures" / "1groupA.svg"
+    output_pdf = tmp_path / "out/pieces.pdf"
+    output_png = tmp_path / "out/layout.png"
+
+    result = subprocess.run(
+        [
+            "python",
+            str(main_py),
+            str(input_svg),
+            "--pdf",
+            str(output_pdf),
+            "--png",
+            str(output_png),
+            "--no-flip",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    if result.returncode != 0:
+        print("STDOUT:", result.stdout)
+        print("STDERR:", result.stderr)
+    assert result.returncode == 0
+    assert output_pdf.exists() and output_pdf.stat().st_size > 0
+    assert output_png.exists() and output_png.stat().st_size > 0

--- a/tests/unit/test_pdf_writer.py
+++ b/tests/unit/test_pdf_writer.py
@@ -104,3 +104,32 @@ def test_draw_label_with_color(tmp_path):
     poly = Polygon([(0, 0), (1, 0), (1, 1), (0, 1)])
     args = LabelDrawArgs(poly_idx=0, rotation=0, dx=0, dy=0, seam_poly=poly)
     writer.draw_label(args)
+
+
+def test_pdfwriterargs_flip_default_true():
+    args = PDFWriterArgs(
+        filename="out.pdf",
+        pages=[],
+        seam_allowances={},
+        polygons=[],
+        groups=[],
+        piece_labels={},
+        label_positions={},
+    )
+    assert args.flip_y is True
+
+
+def test_pdfpolygonwriter_write_no_flip(tmp_path):
+    args = PDFWriterArgs(
+        filename=str(tmp_path / "out.pdf"),
+        pages=[[]],
+        seam_allowances={},
+        polygons=[],
+        groups=[],
+        piece_labels={},
+        label_positions={},
+        flip_y=False,
+    )
+    writer = PDFPolygonWriter(args)
+    writer.write()
+    assert (tmp_path / "out.pdf").is_file()


### PR DESCRIPTION
## Summary
- allow optional no-flip output so pieces are right-side-up
- document the new flag in README
- test PDF writer with flip option
- test CLI e2e with `--no-flip`
- handle flipping per polygon so labels are upright

## Testing
- `pytest -q`